### PR TITLE
LICENSE: Fix typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,4 +23,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
 of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the FreeBSD Project.
+either expressed or implied, of 21 Inc.


### PR DESCRIPTION
This fixes an incorrect reference to the FreeBSD project, from which
this license is derived.